### PR TITLE
Linux Kernel Module Programming Guide has been moved

### DIFF
--- a/docs/Introduction/Zynq7000-EDT/8-custom-ip-driver-linux.md
+++ b/docs/Introduction/Zynq7000-EDT/8-custom-ip-driver-linux.md
@@ -321,8 +321,7 @@ commands, which can be of the following types:
 
 -   Neither read nor write ioctl.
 
-For more details about LKM, refer to the <a href="http://tldp.org/LDP/lkmpg/2.6/html/index.html">Linux Kernel Module
-Programming Guide</a>.
+For more details about LKM, refer to the <a href="https://sysprog21.github.io/lkmpg/">Linux Kernel Module Programming Guide</a>.
 
 In this section you are going to develop a peripheral IP device driver as an LKM, which is dynamically loadable onto the running kernel. You must build the peripheral IP LKM as part of the same kernel build process that generates the base kernel image.
 


### PR DESCRIPTION
The Linux Kernel Module Programming Guide is now maintained and updated
for 5.x kernels. It is hosted at GitHub now.